### PR TITLE
Don't fetch config

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -77,9 +77,9 @@ describe('Test suite for the SDK', () => {
 
     expect(global.rudderanalytics.push).not.toBe(Array.prototype.push);
 
-    // one source config endpoint call and one implicit page call
+    // one implicit page call
     // Refer to above 'beforeEach'
-    expect(xhrMock.send).toHaveBeenCalledTimes(2);
+    expect(xhrMock.send).toHaveBeenCalledTimes(1);
   });
 
   it('If APIs are called, then appropriate network requests are made', () => {
@@ -89,8 +89,8 @@ describe('Test suite for the SDK', () => {
     rudderanalytics.group('jest-group');
     rudderanalytics.alias('new-jest-user', 'jest-user');
 
-    // one source config endpoint call and above API requests
-    expect(xhrMock.send).toHaveBeenCalledTimes(6);
+    // above API requests
+    expect(xhrMock.send).toHaveBeenCalledTimes(5);
   });
 
   describe("Test group for 'getAnonymousId' API", () => {

--- a/analytics.js
+++ b/analytics.js
@@ -1035,19 +1035,20 @@ class Analytics {
           this.processResponse(200, res);
         }
       }
-      return;
+      // return;
     }
 
-    let configUrl = getConfigUrl(writeKey);
-    if (options && options.configUrl) {
-      configUrl = getUserProvidedConfigUrl(options.configUrl, configUrl);
-    }
+    // #### Commented this out since we don't care about the config
+    // let configUrl = getConfigUrl(writeKey);
+    // if (options && options.configUrl) {
+    //   configUrl = getUserProvidedConfigUrl(options.configUrl, configUrl);
+    // }
 
-    try {
-      getJSONTrimmed(this, configUrl, writeKey, this.processResponse);
-    } catch (error) {
-      handleError(error);
-    }
+    // try {
+    //   getJSONTrimmed(this, configUrl, writeKey, this.processResponse);
+    // } catch (error) {
+    //   handleError(error);
+    // }
   }
 
   /**

--- a/dist/rudder-sdk-js/package.json
+++ b/dist/rudder-sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kognic/rudder-sdk-js",
-  "version": "2.17.0-new2",
+  "version": "2.17.1",
   "description": "RudderStack Javascript SDK",
   "main": "index.js",
   "module": "index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kognic/rudder-analytics",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "",
   "main": "./dist/browser.min.js",
   "scripts": {


### PR DESCRIPTION
Since we are only going to send events to our cloud function we don't need to fetch the config.
The config is used to be able to send event directly to other destinations such as GA or amplitude